### PR TITLE
Added trigger for QuestEnd and QuestStateChange to NextState method.

### DIFF
--- a/Diplomata/Models/Quest.cs
+++ b/Diplomata/Models/Quest.cs
@@ -162,10 +162,12 @@ namespace LavaLeak.Diplomata.Models
           if (index == questStates.Length - 1)
           {
             Finish();
+            DiplomataManager.EventController.SendQuestEnd(this);
           }
           else
           {
             currentStateId = questStates[index + 1].GetId();
+            DiplomataManager.EventController.SendQuestStateChange(this);
           }
         }
       }


### PR DESCRIPTION
Global event handler was not functioning when we changed to next state manually with code and not by using the diplomata character.

Added the trigger to be used by the NextState on the quest itself.